### PR TITLE
Fix API Query Use Different Fields

### DIFF
--- a/app/controllers/api/agendas_controller.rb
+++ b/app/controllers/api/agendas_controller.rb
@@ -3,7 +3,7 @@ class Api::AgendasController < ApiController
 		@agendas = if @@query.empty?
 			paginate Agenda.all.order(change_query_order), per_page: change_per_page
 		else
-			paginate Agenda.where("lower(name) LIKE ?", @@query).order(change_query_order), per_page: change_per_page
+			paginate Agenda.where("date = ?", Date.strptime(@@query.gsub("%",""), '%m-%d-%Y')).order(change_query_order), per_page: change_per_page
 		end
 
 		render json: @agendas

--- a/app/controllers/api/councillors_controller.rb
+++ b/app/controllers/api/councillors_controller.rb
@@ -3,7 +3,9 @@ class Api::CouncillorsController < ApiController
   	@councillors = if @@query.empty?
   		paginate Councillor.all.order(change_query_order), per_page: change_per_page
   	else
-			paginate Councillor.where("lower(name) LIKE ?", @@query).order(change_query_order), per_page: change_per_page
+			paginate Councillor.where("lower(first_name) LIKE ? OR 
+        lower(last_name) LIKE ? OR 
+        lower(email) LIKE ?", @@query, @@query, @@query).order(change_query_order), per_page: change_per_page
 		end
 
   	render json: @councillors

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -3,7 +3,8 @@ class Api::ItemsController < ApiController
   	@items = if @@query.empty?
   		paginate Item.all.order(change_query_order), per_page: change_per_page
   	else
-			paginate Item.where("lower(name) LIKE ?", @@query).order(change_query_order), per_page: change_per_page
+			paginate Item.where("lower(title) LIKE ? OR 
+        lower(origin_type) = ?", @@query, @@query.gsub("%", "")).order(change_query_order), per_page: change_per_page
 		end
 
 		render json: @items

--- a/app/controllers/api/motions_controller.rb
+++ b/app/controllers/api/motions_controller.rb
@@ -3,7 +3,7 @@ class Api::MotionsController < ApiController
   	@motions = if @@query.empty?
   		paginate Motion.all.order(change_query_order), per_page: change_per_page
   	else
-			paginate Motion.where("lower(name) LIKE ?", @@query).order(change_query_order), per_page: change_per_page
+			paginate Motion.where("lower(amendment_text) LIKE ?", @@query).order(change_query_order), per_page: change_per_page
 		end
 
   	render json: @motions


### PR DESCRIPTION
Because there are different fields each model uses to hold text or dates each API query should be able to search those fields.
