### PR TITLE
Strip out blank lines, treat content as Markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'faker'
 #used to colour output to the terminal. 
 gem 'colored'
 
+gem 'redcarpet'
 # Jquery UI
 # gem 'jquery-ui-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+    redcarpet (3.2.2)
     sass (3.4.13)
     sass-rails (5.0.1)
       railties (>= 4.0.0, < 5.0)
@@ -235,6 +236,7 @@ DEPENDENCIES
   pg
   pry-byebug
   rails (= 4.2.0)
+  redcarpet
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sorcery

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,5 +8,9 @@ module ApplicationHelper
       CodeRay.scan($3, $2).div(:css => :class)
     end
 	end
-		
+
+  def htmlize(content)
+    @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+    @renderer.render(content)
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,7 +35,7 @@
 				<li class="accordion-navigation <%= "active" if index == 0 %>">
 					<a href="#panel-<%= index %>a"><i class="fa fa-caret-right"></i> <%= title %></a>
 					<div id="panel-<%= index %>a" class="content <%= "active" if index == 0 %>">
-						<%= content.html_safe %>
+						<%= htmlize(content).html_safe %>
 					</div>
 				</li>
 			<% end %>

--- a/lib/parsed_item.rb
+++ b/lib/parsed_item.rb
@@ -67,7 +67,8 @@ class ParsedItem
 			if node.css('p').length > 0
 				sections[current_section] << node.css('p')
 																				 .map(&:text)
-																				 .join(" ")
+																				 .reject(&:blank?)
+																				 .join("\n\n")
 			elsif is_header?(node)
 				current_section = node.text
 				sections[current_section] = ""


### PR DESCRIPTION
There was some weird stuff going with blank lines messing
up the HTMLification of stuff so strips out blank lines.

With lines being somewhat reliable we can just run each
section through a markdown parser and dump out the resulting
HTML. It's structured a bit better so you can read it and such.
# Demo

![](http://dl.dropbox.com/u/113966/Screenshots/bwlg38q44h59.png)

Please review @ScottKbka @emilyjfan @SpiritBreaker226 
