### PR TITLE
Fix Foundation JavaScript From Displaying Errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'ox'
 # for api serilization
 gem 'active_model_serializers'
 # Foundation Scss framework
-gem 'foundation-rails'
+gem 'foundation-rails', '5.5.1.0'
 # for awesome icons
 gem 'font-awesome-sass'
 # Code syntax highlighting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       thor (~> 0.14)
     font-awesome-sass (4.3.2.1)
       sass (~> 3.2)
-    foundation-rails (5.5.1.1)
+    foundation-rails (5.5.1.0)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
     globalid (0.3.3)
@@ -223,7 +223,7 @@ DEPENDENCIES
   favorite_things
   figaro
   font-awesome-sass
-  foundation-rails
+  foundation-rails (= 5.5.1.0)
   http
   jbuilder (~> 2.0)
   jquery-rails


### PR DESCRIPTION
Fix the Foundation JavaScript from displaying errors, in the console
since there is an error, in the foundation rails gem 5.5.1.1. Where any
foundation component such as accordion, which that uses JavaScript will
not not work.

_Please run `bundle`, in the console. in order to install the version 5.5.1.0 of foundation rails gem, which does work_
