### PR TITLE
Scraping current term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore Public Assests
 /public/assets/*
+
+#ignore scott's notes on launching okc
+launching-okc.md

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@
 # Ignore Public Assests
 /public/assets/*
 
-#ignore scott's notes on launching okc
-launching-okc.md
+#ignore scott's notes dir
+/notes/*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clone the project
 
 `cd` into the project directory and run `bundle install`.
 
-Run `rake db:setup` to download the City Council Agenda and votes from December 2015 to today's date and seed the database. The project currently contains a mix of real and fake data, as the scraper is continually a work in progress. 
+Run `rake db:setup` to download the City Council Agenda and votes from December 2014 to today's date and seed the database. The project currently contains a mix of real and fake data, as the scraper is continually a work in progress. 
 
 ## Contributing
 We'd love to see what others can do with this project. If you'd like to contribute to this project, please fork the repo and create a pull request of your changes.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clone the project
 
 `cd` into the project directory and run `bundle install`.
 
-Run `rake okc:fresh` to download the City Council Agenda and votes from February 2015 and seed the database. The project currently contains a mix of real and fake data, as the scraper is continually a work in progress. 
+Run `rake db:setup` to download the City Council Agenda and votes from December 2015 to today's date and seed the database. The project currently contains a mix of real and fake data, as the scraper is continually a work in progress. 
 
 ## Contributing
 We'd love to see what others can do with this project. If you'd like to contribute to this project, please fork the repo and create a pull request of your changes.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,14 +4,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   rescue_from CanCan::AccessDenied do |exception|
-    @item = find_action_item_type_in_item().first if @item == nil
+    @item = find_action_item_type_in_item.first if @item == nil
 
     redirect_to item_path(@item), :notice => exception.message
   end
 
   def find_next_item(user)
     if user.nil? || user.has_no_votes?
-  		find_action_item_type_in_item().first
+  		find_action_item_type_in_item.first
   	else
 	  	get_items_to_vote_on(user).order(:id).first.id
 	  end
@@ -23,11 +23,11 @@ class ApplicationController < ActionController::Base
   end
 
   def get_items_to_vote_on(user) 
-    find_action_item_type_in_item().where('items.id NOT IN (?)', get_item_id_from_vote(user))
+    find_action_item_type_in_item.where('items.id NOT IN (?)', get_item_id_from_vote(user))
   end
 
   private
-  def find_action_item_type_in_item()
+  def find_action_item_type_in_item
     Item.includes(:item_type).where(item_types: { name: "Action" })
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   end
 
   def get_items_to_vote_on(user) 
-    Item.where('id NOT IN (?)', get_item_id_from_vote(user)).where(item_type_id: 1)
+    find_action_item_type_in_item().where('items.id NOT IN (?)', get_item_id_from_vote(user))
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,14 +4,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   
   rescue_from CanCan::AccessDenied do |exception|
-    @item = Item.where(item_type_id: 1).first if @item == nil
+    @item = find_action_item_type_in_item().first if @item == nil
 
     redirect_to item_path(@item), :notice => exception.message
   end
 
   def find_next_item(user)
     if user.nil? || user.has_no_votes?
-  		Item.where(item_type_id: 1).first
+  		find_action_item_type_in_item().first
   	else
 	  	get_items_to_vote_on(user).order(:id).first.id
 	  end
@@ -24,5 +24,10 @@ class ApplicationController < ActionController::Base
 
   def get_items_to_vote_on(user) 
     Item.where('id NOT IN (?)', get_item_id_from_vote(user)).where(item_type_id: 1)
+  end
+
+  private
+  def find_action_item_type_in_item()
+    Item.includes(:item_type).where(item_types: { name: "Action" })
   end
 end

--- a/lib/agenda_scraper.rb
+++ b/lib/agenda_scraper.rb
@@ -11,21 +11,21 @@ class AgendaScraper
   end
 
   def get_agendas
-    id = "9688"
-    #@ids.map do |id| # Check if the file exists, if not, download it.
+    @ids.map do |id| # Check if the file exists, if not, download it.
       file_name = "#{@raw_file_dir}/#{id}.html"
       unless File.exist? file_name
         print "Calling the internet and saving agenda #{id}".yellow
         save(file_name, RawDocument.new(:agendas, id).content)
         puts " ✔ "
       end
-    #end  
+    end  
   end
   
   def parse_agendas
-  # Temporarily remove the loop for OKC
-  # @ids.each do |id|
-    id = "9688"
+    puts "I am about to parse #{@ids.count} items. How do you feel about that?"
+    response = gets.chomp
+        
+    @ids.each do |id|
     print "\nParsing #{id} "
     
     content      = open("#{@raw_file_dir}/#{id}.html").read
@@ -65,7 +65,7 @@ class AgendaScraper
         print "⚡"
   		end
   	end
-  # end
+   end
   end
 
   def run

--- a/lib/agenda_scraper.rb
+++ b/lib/agenda_scraper.rb
@@ -5,9 +5,9 @@ require 'parsed_item'
 class AgendaScraper
   include Scraper
 
-  def initialize
+  def initialize(date)
     @raw_file_dir = raw_file_dir(:agendas)
-    @ids          = MeetingIDs.new(12, 2015).ids
+    @ids          = MeetingIDs.new(date).ids
   end
 
   def get_agendas
@@ -22,50 +22,47 @@ class AgendaScraper
   end
   
   def parse_agendas
-    puts "I am about to parse #{@ids.count} items. How do you feel about that?"
-    response = gets.chomp
         
     @ids.each do |id|
-    print "\nParsing #{id} "
-    
-    content      = open("#{@raw_file_dir}/#{id}.html").read
-    sections     = content.split("<br clear=\"all\">")
-    items        = sections.map { |item| Nokogiri::HTML(item) }
-    @header_info = Nokogiri::HTML(items[1].to_s.split('<hr')[0])
+      print "\nParsing #{id} "
 
-    def date
-      @header_info.at('tr[2]/td[2]')
-                  .at('br')
-                  .previous_sibling
-                  .text
-                  .strip
+      content      = open("#{@raw_file_dir}/#{id}.html").read
+      sections     = content.split("<br clear=\"all\">")
+      items        = sections.map { |item| Nokogiri::HTML(item) }
+      @header_info = Nokogiri::HTML(items[1].to_s.split('<hr')[0])
+      def date
+        @header_info.at('tr[2]/td[2]')
+                    .at('br')
+                    .previous_sibling
+                    .text
+                    .strip
+      end
+
+      def meeting_num
+        @header_info.at('tr/td[2]').text.strip
+      end
+
+      # find the date & meeting number and create a meeting in the db
+      council = Committee.where("name = 'City Council'")
+
+      @agenda = Agenda.create!({
+        date:         date,
+        meeting_num:  meeting_num,
+        committee_id: council.ids[0]
+      })
+
+      items.each do |item|
+      	item_number = item.xpath("//table[@class='border']/tr/td/font[@size='5']").text
+
+      	unless item_number.empty?
+      		parsed_agenda_item = ParsedItem.new(item_number, item).to_h
+          parsed_agenda_item[:origin_id] = @agenda.id
+          parsed_agenda_item[:origin_type] = "Agenda"
+      		Item.create!(parsed_agenda_item)
+          print "⚡"
+      	end
+      end
     end
-
-    def meeting_num
-      @header_info.at('tr/td[2]').text.strip
-    end
-
-    # find the date & meeting number and create a meeting in the db
-    council = Committee.where("name = 'City Council'")
-
-    @agenda = Agenda.create!({
-      date:         date,
-      meeting_num:  meeting_num,
-      committee_id: council.ids[0]
-    })
-  	
-    items.each do |item|
-  		item_number = item.xpath("//table[@class='border']/tr/td/font[@size='5']").text
-
-  		unless item_number.empty?
-  			parsed_agenda_item = ParsedItem.new(item_number, item).to_h
-        parsed_agenda_item[:origin_id] = @agenda.id
-        parsed_agenda_item[:origin_type] = "Agenda"
-  			Item.create!(parsed_agenda_item)
-        print "⚡"
-  		end
-  	end
-   end
   end
 
   def run

--- a/lib/agenda_scraper.rb
+++ b/lib/agenda_scraper.rb
@@ -24,7 +24,7 @@ class AgendaScraper
   def parse_agendas
         
     @ids.each do |id|
-      print "\nParsing #{id} "
+      print "Parsing #{id} "
 
       content      = open("#{@raw_file_dir}/#{id}.html").read
       sections     = content.split("<br clear=\"all\">")
@@ -62,12 +62,13 @@ class AgendaScraper
           print "⚡"
       	end
       end
+      print "\n"
     end
   end
 
   def run
     get_agendas
     parse_agendas
-    puts "\n★ ★ ★  DONE PARSING ★ ★ ★".green
+    puts "\n★ ★ ★  DONE PARSING ★ ★ ★\n".green
   end
 end

--- a/lib/meeting_ids.rb
+++ b/lib/meeting_ids.rb
@@ -3,9 +3,12 @@ class MeetingIDs
 
 	attr_reader :ids
 
+	# TO DO: Pass scrape decision body IDs and pass them into this class to get
+	# 			 meeting IDs for different committees.
 	def initialize(date)
-		@now = date
-		@ids = meeting_ids
+		@now           = date
+		@decision_body = "961"
+		@ids           = meeting_ids
 	end
 
 	private
@@ -19,7 +22,7 @@ class MeetingIDs
 	end
 
 	def meeting_page
-  	url  = "decisionBodyProfile.do?function=doPrepare&decisionBodyId=961"
+  	url  = "decisionBodyProfile.do?function=doPrepare&decisionBodyId=#{@decision_body}"
 		page = get url
 		Nokogiri::HTML(page)
 	end

--- a/lib/meeting_ids.rb
+++ b/lib/meeting_ids.rb
@@ -4,9 +4,8 @@ class MeetingIDs
 	attr_reader :ids
 
 	def initialize(date)
-		@month = date.month
-		@year  = date.year
-		@ids   = meeting_ids
+		@now = date
+		@ids = meeting_ids
 	end
 
 	private
@@ -14,27 +13,20 @@ class MeetingIDs
 	def meeting_ids
 		page        = meeting_page
 		headers     = page.css("h3").to_ary
-		
-		ids = headers.map do |header|
-		  header.attr("id").remove("header") if !future? header
+		headers.map do |header|
+		  header.attr("id").remove("header") if past_meeting? header
 		end.flatten.reject(&:nil?)
-			 binding.pry; 1
 	end
 
 	def meeting_page
-  	url  = URI "http://app.toronto.ca/tmmis/decisionBodyProfile.do?function=doPrepare&decisionBodyId=961"
-		page = HTTP.get(url).to_s
+  	url  = "decisionBodyProfile.do?function=doPrepare&decisionBodyId=961"
+		page = get url
 		Nokogiri::HTML(page)
 	end
 
-	def future?(header)
-		month_names = %w(January February March April May June July August September October November December)
-		binding.pry
-		month_names[0..@month-1].map do |month|
-			unless header.text.include?(month) || !header.text.include?(@year.to_s)
-				false
-			end
-		end
+	def past_meeting?(header)
+		meeting_date = DateTime.parse(header.text.split("-")[0].strip)
+		@now - meeting_date > 0 ? true : false
 	end
 
 end

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -1,14 +1,11 @@
 module Scraper
 
 	def post url, params = {}
-    HTTP.post("http://app.toronto.ca/tmmis/#{url}", form: params)
-        .body
-        .to_s
+    HTTP.post("http://app.toronto.ca/tmmis/#{url}", form: params).body.to_s
   end
   
   def get url
-    HTTP.get "http://app.toronto.ca/tmmis/#{url}"
-        .to_s
+    HTTP.get("http://app.toronto.ca/tmmis/#{url}").to_s
   end
   
   def save(file_name, content)

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -1,13 +1,14 @@
 module Scraper
 
-	def post(url, params)
+	def post url, params = {}
     HTTP.post("http://app.toronto.ca/tmmis/#{url}", form: params)
-    .body
-    .to_s
+        .body
+        .to_s
   end
   
-  def get(url)
-    HTTP.get("http://app.toronto.ca/tmmis/#{url}")
+  def get url
+    HTTP.get "http://app.toronto.ca/tmmis/#{url}"
+        .to_s
   end
   
   def save(file_name, content)

--- a/lib/tasks/okc.rake
+++ b/lib/tasks/okc.rake
@@ -25,7 +25,7 @@ namespace :okc do
   task fresh: [:environment, 'db:drop', 'db:create', 'db:migrate', :agendas, 'db:seed', :votes] do
     puts "############################".magenta_on_white
     puts "                            ".magenta_on_white
-    puts "💖 You look great today! 💖".magenta_on_white
+    puts "💖  You look great today!  💖 ".magenta_on_white
     puts "                            ".magenta_on_white
     puts "############################".magenta_on_white
   end
@@ -96,7 +96,7 @@ namespace :okc do
     @council = Committee.create!({
       name: "City Council",
     })
-    AgendaScraper.new(Time.now).run
+    AgendaScraper.new(DateTime.now).run
   end
 
   ##################################################################

--- a/lib/tasks/okc.rake
+++ b/lib/tasks/okc.rake
@@ -68,7 +68,7 @@ namespace :okc do
     # Rake.application.rake_require File.expand_path('../../../app/models/raw_vote_record.rb', __FILE__)
     puts "Destroying the vote record".red
     RawVoteRecord.destroy_all
-    VoteScraper.new(6, "2015-02-01", "2015-02-15").run
+    VoteScraper.new(6, "2015-01-01", "2015-04-30").run
     # to change the date range and the term for the votes, you need
     # to changne the above info and change the params for getting 
     # the csvs. e.g., The decision body ID for 2014 is 961 but it is
@@ -96,7 +96,7 @@ namespace :okc do
     @council = Committee.create!({
       name: "City Council",
     })
-    AgendaScraper.new.run
+    AgendaScraper.new(Time.now).run
   end
 
   ##################################################################

--- a/lib/tasks/okc.rake
+++ b/lib/tasks/okc.rake
@@ -23,7 +23,11 @@ namespace :okc do
 
   desc "Gimme a fresh start. Drops the db and parses the data again."
   task fresh: [:environment, 'db:drop', 'db:create', 'db:migrate', :agendas, 'db:seed', :votes] do
-    puts "You look great today.".magenta_on_white
+    puts "############################".magenta_on_white
+    puts "                            ".magenta_on_white
+    puts "💖 You look great today! 💖".magenta_on_white
+    puts "                            ".magenta_on_white
+    puts "############################".magenta_on_white
   end
 
   desc"Clears out items table"

--- a/lib/tasks/okc.rake
+++ b/lib/tasks/okc.rake
@@ -96,6 +96,8 @@ namespace :okc do
     @council = Committee.create!({
       name: "City Council",
     })
+    # TO DO: Pass in a setup boolean. If true then scrape all the data. If false, 
+    #        check when it was run last and grab the new information.
     AgendaScraper.new(DateTime.now).run
   end
 

--- a/lib/tasks/okc.rake
+++ b/lib/tasks/okc.rake
@@ -15,47 +15,6 @@ require 'minutes_scraper'
 
 namespace :okc do
   
-  ##################################################################
-  #                                                                #
-  # GET FRESH                                                      #
-  #                                                                #
-  ##################################################################
-
-  desc "Gimme a fresh start. Drops the db and parses the data again."
-  task fresh: [:environment, 'db:drop', 'db:create', 'db:migrate', :agendas, 'db:seed', :votes] do
-    puts "############################".magenta_on_white
-    puts "                            ".magenta_on_white
-    puts "💖  You look great today!  💖 ".magenta_on_white
-    puts "                            ".magenta_on_white
-    puts "############################".magenta_on_white
-  end
-
-  desc"Clears out items table"
-  task destroy_items: :environment do
-  	Item.destroy_all
-  end
-
-  ##################################################################
-  #                                                                #
-  # TEST PARSER                                                    #
-  #                                                                #
-  ##################################################################
-  
-  desc "Tests ParsedItem on a single file"
-  task test_parser: [:destroy_items] do |t| 
-    content  = open("lib/dirty_agendas/7849.html").read
-    sections = content.split("<br clear=\"all\">")
-    items    = sections.map { |item| Nokogiri::HTML(item) }
-    
-    items.each do |item|
-      item_number = item.xpath("//table[@class='border']/tr/td/font[@size='5']").text
-
-      unless item_number.empty?
-        parsed_agenda_item = ParsedItem.new(item_number, item).to_h
-        Item.create(parsed_agenda_item)
-      end
-    end
-  end
 
   ##################################################################
   #                                                                #
@@ -65,14 +24,10 @@ namespace :okc do
 
   desc "Scrapes, parses & persists raw vote records"
   task :votes do
-    # Rake.application.rake_require File.expand_path('../../../app/models/raw_vote_record.rb', __FILE__)
-    puts "Destroying the vote record".red
-    RawVoteRecord.destroy_all
-    VoteScraper.new(6, "2015-01-01", "2015-04-30").run
-    # to change the date range and the term for the votes, you need
-    # to changne the above info and change the params for getting 
-    # the csvs. e.g., The decision body ID for 2014 is 961 but it is
-    # 261 for last term.
+    puts "This does nothing right now. Check the rake file for a To Do note.".yellow
+    # TO DO: Pass in the date of the most recent vote record, then get the scraper
+    #        to check if there are new votes to scrape
+    #VoteScraper.new(6, "2015-01-01", "2015-04-30").run
   end
 
   ##################################################################
@@ -83,22 +38,10 @@ namespace :okc do
   
   desc "Scrape, parse & persist City Council agendas"
   task :agendas do |t|
-    puts "Creating Item Types".blue
-    item_types = ItemType.create!([
-      { name: 'Action' }, 
-      { name: 'Information' }, 
-      { name: 'Presentation' }
-    ])
-    # TODO: Move this into its own scraper
-    puts "Destroying Committees".red
-    Committee.destroy_all
-    puts "Creating City Council".blue
-    @council = Committee.create!({
-      name: "City Council",
-    })
-    # TO DO: Pass in a setup boolean. If true then scrape all the data. If false, 
-    #        check when it was run last and grab the new information.
-    AgendaScraper.new(DateTime.now).run
+    puts "This does nothing right now. Check the rake file for a To Do note.".yellow
+    # TO DO: Pass in the date of the most recend Agenda, then get the scraper
+    #        to check if there are any new agendas to scrape.
+    # AgendaScraper.new(DateTime.now).run
   end
 
   ##################################################################
@@ -109,7 +52,12 @@ namespace :okc do
   
   desc "Scrape Minutes"
   task :minutes do |t|
-    MinutesScraper.new.run
+    puts "This does nothing right now. Check the rake file for a To Do note.".yellow
+    # TO DO: Get the minuts scraper to parse minuts. This is similar to the agenda
+    #        scraper except that minutes have motions.
+    # MinutesScraper.new.run
   end
+
+  # TO DO: Create a Decision Document Scraper and parser.
 
 end

--- a/lib/vote_scraper.rb
+++ b/lib/vote_scraper.rb
@@ -8,19 +8,19 @@ class VoteScraper
     @url           = "getAdminReport.do"
     @from_date     = from_date
     @to_date       = to_date
-    @member_emoji  = %w(😀 😁 😂 😃 😄 😅 😆 😇 😈)
+    @member_emoji  = %w(😀 😁 😂 😃 😄 😅 😆 😇)
     @members       = get_members(@term_id)
   end
 
   def run
 
-    puts "Getting member vote reports"
+    puts "Getting the vote record for 2014-12-01 to #{@to_date}".blue
     
     @members[1..-1].each do |member|
       unless File.exist? "#{file_name(member[:name])}.csv"
         get_vote_record(member)
       end
-      puts "Parsing vote record for #{member[:name]} 💚 "
+      puts "Parsing vote record for #{member[:name]} 👍 "
       parse_vote_record(member)
     end
   end

--- a/lib/vote_scraper.rb
+++ b/lib/vote_scraper.rb
@@ -2,13 +2,14 @@ class VoteScraper
   include Scraper
 
   def initialize(term_id, from_date, to_date)
-    @term_id      = term_id
-    @raw_file_dir = "#{raw_file_dir(:votes)}/"
-    @url          = "getAdminReport.do"
-    @from_date    = from_date
-    @to_date      = to_date
-    @member_emoji = %w(😀 😁 😂 😃 😄 😅 😆 😇 😈)
-    @members      = get_members(@term_id)
+    @term_id       = term_id
+    @decision_body = 961
+    @raw_file_dir  = "#{raw_file_dir(:votes)}/"
+    @url           = "getAdminReport.do"
+    @from_date     = from_date
+    @to_date       = to_date
+    @member_emoji  = %w(😀 😁 😂 😃 😄 😅 😆 😇 😈)
+    @members       = get_members(@term_id)
   end
 
   def run
@@ -111,7 +112,7 @@ class VoteScraper
         # TO DO: scrape decision body ids with councillor ids
         # city council for last term is 261, for all committees, 0
         # for current term 961. why?
-        decisionBodyId: 961, 
+        decisionBodyId: @decision_body, 
         fromDate: "",#@from_date,
         toDate: "" #@to_date
       }

--- a/lib/vote_scraper.rb
+++ b/lib/vote_scraper.rb
@@ -58,10 +58,10 @@ class VoteScraper
 
   def open_vote_record(member)
     csv = File.open(file_name(member[:name]), 'r')
-    CSV.parse(csv, headers: true, header_converters: sake_case_headers)
+    CSV.parse(csv, headers: true, header_converters: snake_case_headers)
   end
 
-  def sake_case_headers
+  def snake_case_headers
     lambda { |h| h.try(:parameterize).try(:underscore) }
   end
 


### PR DESCRIPTION
This commit removes `rake okc:fresh` and puts all of those tasks into the seed.rb file. I did this so that we can use all of the built in `db` rake tasks. 
- To get set up run `rake db:setup`
- To clear out the city council data and populate everything again, run `rake db:seed`
- `rake db:seed` creates one fake user but it does not delete users. This is so that we can run the seeds again if we need to without deleting user info.
- The fake user no longer has any votes.
- City Councillors no longer have any fake votes either. This means that CouncillorVotes table is empty as we were populating this with OKC votes (likes), not real votes.

@SpiritBreaker226 or @emilyjfan, Can you review this?
